### PR TITLE
Removed Github state redundancy across pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,11 +37,7 @@ jobs:
       - name: Build static site 🔧
         env:
           FAIRTRACKS_GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FAIRTRACKS_USE_PROD_GITHUB_REPOS_IN_DEV: true
         run: |
-          npm run waitforserve:dev
-          ls -l .githubRepoInfo.json
-          npm run clean:build
           npm run generate
 
       - name: Deploy 🚀

--- a/content/markdown/code/code-07-hyperbrowser.md
+++ b/content/markdown/code/code-07-hyperbrowser.md
@@ -5,5 +5,5 @@ name: genomic-hyperbrowser
 branch:
 parentCommit: 3ca800015becec1127ff10d58b6a8b8bb064130d
 includeInDev: false
-includeInProd: true
+includeInProd: false
 ---

--- a/store/index.js
+++ b/store/index.js
@@ -7,16 +7,24 @@ import dataActions from '~/store/data/actions'
 import database from '~/database'
 import githubActions from '~/store/github/actions'
 
+export function getPageIfProd(route) {
+  if (process.env.NODE_ENV === 'production') {
+    return route.name
+  } else {
+    return null
+  }
+}
+
 export const actions = {
   async nuxtServerInit(store, context) {
     async function initAllStores(store, context) {
-      await imageAssetActions.nuxtServerInit(store, context)
-      iconRegisterActions.nuxtServerInit(store, context)
-      await mdRegisterActions.nuxtServerInit(store, context)
-      await dataActions.nuxtServerInit(store, context)
-      await database.init(store, context)
-      if (process.server) {
-        await githubActions.nuxtServerInit(store, context)
+      await imageAssetActions.nuxtServerInit(store, context) // 19.4k
+      iconRegisterActions.nuxtServerInit(store, context) // 12.7k
+      await mdRegisterActions.nuxtServerInit(store, context) // 95.8k
+      await dataActions.nuxtServerInit(store, context) // 25.9k
+      await database.init(store, context) // 16.7k
+      if (getPageIfProd(context.route) === 'code') {
+        await githubActions.nuxtServerInit(store, context) // 1996k
       }
     }
 


### PR DESCRIPTION
Github repo info was unnecessarily included in all page state.js files, slowing up user experience (and giving low lighthouse score). Is now only included in the state of the `code` page. Most of the contents can also be pruned away (for later).

Removed unneeded deployment workflow hack.

Other space saving efforts for state storage is possible (an failed attempt at markdown duplication removal is included). However, removal of GitHub info redundance was a low effort - high gain solution. The rest is lower priority.

Lighthouse performance score should increase dramatically now (was 70)!